### PR TITLE
Clarify vendordep installation

### DIFF
--- a/overview/our-features/README.md
+++ b/overview/our-features/README.md
@@ -16,7 +16,7 @@ Example code repository
 
 ## Easy installation
 
-Just download all of the vendordeps from WPILib online with this list.[#vendor-urls](../../configuring-yagsl/dependency-installation.md#vendor-urls "mention")
+Just download all of the vendordeps from WPILib online from this list: [#vendor-urls](../../configuring-yagsl/dependency-installation.md#vendor-urls "mention") following the process at:
 
 {% embed url="https://docs.wpilib.org/en/stable/docs/software/vscode-overview/3rd-party-libraries.html#rd-party-libraries" %}
 


### PR DESCRIPTION
If someone missed the first link, it reads like install all vendordeps on the WPILib docs page, which is more then is needed