### PR TITLE
Fix SparkMaxAnalog5v example code

### DIFF
--- a/devices/absolute-encoders.md
+++ b/devices/absolute-encoders.md
@@ -159,7 +159,7 @@ Try inverting your steering/angle/azimuth motor if your module keeps spinning ar
 
 [^20]: ```json
     "encoder": {
-        "type": "sparkmax_analog",
+        "type": "sparkmax_analog5v",
         "id": 11,
         "canbus": null
       },


### PR DESCRIPTION
"encoder": {
    "type": "sparkmax_analog",
    "id": 11,
    "canbus": null
  },

to this for sparkmax_analog5v:

"encoder": {
    "type": "sparkmax_analog5v",
    "id": 11,
    "canbus": null
  },