### PR TITLE
Add NavX3-CAN documentation and config guidance

### DIFF
--- a/devices/gyroscope.md
+++ b/devices/gyroscope.md
@@ -96,6 +96,7 @@ If your robot spins out of control without any controller input you probably nee
 | [NavX](gyroscope/navx.md)                                               | `navx_i2c`          | I2C port on the roboRIO MXP. Not recommended!      |
 | [NavX](gyroscope/navx.md)                                               | `navx_usb`          | Serial over USB Cable to roboRIO (not recommended) |
 | [NavX](gyroscope/navx.md)                                               | `navx_mxp_serial`   | Serial over roboRIO MXP                            |
+| [NavX3](gyroscope/navx3.md)                                            | `navx3`             | CAN                                                |
 | [ADIS16448](gyroscope/adis16448.md)                                     | `adis16448`         | roboRIO MXP                                        |
 | [ADIS16470](gyroscope/adis16470.md)                                     | `adis16470`         | roboRIO SPI port                                   |
 | [ADXRS450](gyroscope/adxrs450.md)                                       | `adxrs450`          | roboRIO SPI port.                                  |

--- a/devices/gyroscope/navx3.md
+++ b/devices/gyroscope/navx3.md
@@ -1,0 +1,55 @@
+# NavX3-CAN
+
+
+
+{% hint style="info" %}
+NavX3-CAN supports CAN 2.0 (roboRIO) and has CAN-FD capability. See Studica’s notes for CAN-FD requirements.
+{% endhint %}
+
+## Documentation
+
+{% embed url="https://www.studica.co/navx3-can-imu" %}
+Studica product page
+{% endembed %}
+
+{% embed url="https://github.com/Studica-Robotics/NavX" %}
+Studica NavX releases, firmware tools, and vendordeps
+{% endembed %}
+
+## YAGSL Checklist
+
+* [ ] Install **StudicaLib** vendordep (do not install both Studica and StudicaLib).
+* [ ] Update NavX3-CAN firmware to **5.0.4+** using Studica Hardware Manager.
+* [ ] Use Studica Hardware Manager to find the NavX3-CAN CAN ID and enter it in your config (often ships as 0).
+
+## Calibration
+
+NavX3-CAN ships factory-calibrated. If you want higher accuracy, use Studica Hardware Manager to re-calibrate; the sensor auto-detects its orientation during calibration.
+
+## Communication
+
+NavX3-CAN communicates over CAN. Connect CAN-H/CAN-L to the robot CAN bus and ensure the bus is properly terminated.
+
+## Example `swervedrive.json`
+
+<pre class="language-json"><code class="lang-json">{
+  "imu": {
+    "type": <a data-footnote-ref href="#user-content-fn-1">"navx3"</a>,
+    "id": <a data-footnote-ref href="#user-content-fn-2">0</a>,
+    "canbus": <a data-footnote-ref href="#user-content-fn-3">null</a>
+  },
+  "invertedIMU": <a data-footnote-ref href="#user-content-fn-4">false</a>,
+  "modules": [
+    "frontleft.json",
+    "frontright.json",
+    "backleft.json",
+    "backright.json"
+  ]
+}
+</code></pre>
+
+[^1]: Select the `navx3` IMU device to instantiate and use.
+
+[^2]: CAN ID of the NavX3-CAN as shown in Studica Hardware Manager (often ships as 0).
+
+[^3]: Set to `null` (or omit). `canbus` is CTRE-only and is not used for navX3.


### PR DESCRIPTION
- Document navX3-CAN support in YAGSL docs (new page with config example + checklist)
- Add navX3-CAN to the gyroscope types list
- Clarify canbus is CTRE-only (no CANivore implications for navX3)
- Avoid asserting a fixed default CAN ID; instruct users to verify via Studica Hardware Manager

Files changed:
- devices/gyroscope.md

Files added:
- devices/gyroscope/navx3.md